### PR TITLE
chore: set node versions to those we support

### DIFF
--- a/vars/javascript.groovy
+++ b/vars/javascript.groovy
@@ -1,8 +1,8 @@
 import groovy.transform.Field
 // Which NodeJS versions to test on
 @Field final List defaultNodeVersions = [
-  '8.11.1',
-  '9.2.0'
+  '8.11.3',
+  '10.4.1'
 ]
 // Which OSes to test on
 @Field final List osToTests = [


### PR DESCRIPTION
There are occasional segfaults with Node 9x on the Mac Jenkins workers.  Considering [we don't officially support node 9x](https://github.com/ipfs/community/blob/master/js-code-guidelines.md#supported-versions) we can probably remove it and test on Current & LTS versions instead.