### PR TITLE
fix: use rmdir to delete node_modules folder

### DIFF
--- a/vars/javascript.groovy
+++ b/vars/javascript.groovy
@@ -26,7 +26,7 @@ def windowsStep (version, customModules, buildStep) {
     fileExists 'package.json'
     nodejs(version) {
       // delete node_modules if it's there
-      bat 'del /s /q node_modules >nul 2>&1'
+      bat 'Cmd /C "rmdir /S /Q node_modules"'
       // install local version of yarn (prevent concurrency issues again)
       bat 'npm install yarn@' + yarnVersion
       // force visual studio version


### PR DESCRIPTION
If node_modules is deeply nested, the Windows `del` command will fail to delete the folder as the paths will be too long.  Use `rmdir` in `cmd.exe` to do this instead.