### PR TITLE
[WIP] Transifex automation

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ A script that sits in `ci/Jenkinsfile` can access these library functions by cal
 - [Golang](#golang)
 - [JavaScript](#javascript)
 - [Website](#website-preview-and-deployment-hugo-only)
+- [Transifex](#transifex)
 
 ## Electron Forge
 
@@ -111,6 +112,15 @@ website([
     'master': '_dnslink.dev',
   ]
 ])
+```
+
+## Transifex
+
+Uploads source language to [Transifex](https://www.transifex.com/ipfs/public/).
+Runs `tx push -s` if build is for `master` branch that includes `.tx/config`.
+
+```groovy
+transifex()
 ```
 
 ## License

--- a/vars/transifex.groovy
+++ b/vars/transifex.groovy
@@ -1,0 +1,22 @@
+def call() {
+    timeout(time: 1, unit: 'HOURS') {
+        stage('tx push -s') {
+            node(label: 'linux') {
+            ansiColor('xterm') {
+                // IF build is for master branch (eg. after PR merge)
+                if ( "$BRANCH_NAME" == "master" ) {
+                    def gitInfo = checkout scm
+                    // AND only if project includes Transifex config file
+                    if ( "$gitInfo.GIT_BRANCH" == "master" && fileExists('.tx/config') ) {
+                        // THEN run locale sync in ephemeral container using API token from Jenkins env
+                        sh "docker run --rm -it -e TX_TOKEN=\"\$TX_TOKEN\" -v \$(pwd):/project lidel/ci-transifex tx push -s --root /project"
+                    } else {
+                        echo 'Transifex sync was skipped: .tx/config is missing'
+                        currentBuild.result = "UNSTABLE"
+                    }
+                }
+            }
+            }
+        }
+    }
+}


### PR DESCRIPTION
> # Update: this may not be necessary: https://github.com/ipfs/ipfs-gui/issues/50#issuecomment-419680213 :man_facepalming:

<details>
  <summary>Click to expand anyway</summary>

> This is a part of  [Translation Project for IPFS GUIs](https://github.com/ipfs/ipfs-gui/issues/50), see it for more context. 

The goal of this  PR is to  add `transifex()` script support to `ci/Jenkinsfile`.

We want to make it easy for IPFS projects to add translations. A big help would  be if CI could automatically publish new strings from  source language  (`en`) to [Transifex](https://www.transifex.com/ipfs/public/) via the [`tx` CLI tool](https://docs.transifex.com/client/introduction). That way translators would get notified about new strings  to translate on the same day they land in `master` branch.



The `transifex()` script should run only:
- when `master` branch is built (eg. after PR merge)
- and only if `.tx/config` file is present (it means project is added to Transifex) 


The setup is similar to [ci-websites/](https://github.com/ipfs/ci-websites/):  `tx` (Transifex CLI client) is a python app that runs in an ephemeral container [ci-transifex](https://github.com/lidel/ci-transifex).

## TODO
- [x] decide if missing `.tx/config` should  make build unstable, fail it, or do nothing
    - it marks it `UNSTABLE` for now – as a hint `transifex()` is a no-op
- [ ] find a way to store and pass Transifex API key as `$TX_TOKEN` 
    - probably blocked by: https://github.com/ipfs/testing/issues/18 
- [ ] create Transifex account for ci.ipfs.team  and generate API key using that account
- [ ] move [lidel/ci-transifex](https://github.com/lidel/ci-transifex) to `ipfs/ci-transifex` ?

</details>