### PR TITLE
Refactor of the JavaScript pipeline

### DIFF
--- a/vars/javascript.groovy
+++ b/vars/javascript.groovy
@@ -1,107 +1,3 @@
-import groovy.transform.Field
-// Which NodeJS versions to test on
-@Field final List defaultNodeVersions = [
-  '8.11.3',
-  '10.4.1'
-]
-// Which OSes to test on
-@Field final List osToTests = [
-  'macos',
-  'windows',
-  'linux'
-]
-// Global for which yarn version to use
-@Field final String yarnVersion = '1.7.0'
-// Global for having the path to yarn (prevent concurrency issue with yarn cache)
-@Field final String yarnPath = './node_modules/.bin/yarn --registry="https://registry.npmjs.com"'
-// Global for how many times `yarn install` should be retried if failing
-@Field final Integer yarnInstallRetries = 3
-
-// Step for running tests on a specific nodejs version with windows
-def windowsStep (version, customModules, buildStep) {
-  node(label: 'windows') { ansiColor('xterm') { withEnv(['CI=true']) {
-    def ciContext = 'ci/jenkins/windows/' + version + '/' + buildStep
-    githubNotify description: 'Tests in progress',  status: 'PENDING', context: ciContext
-    // need to make sure we're using the right line endings
-    bat 'git config --global core.autocrlf input'
-    checkout scm
-    fileExists 'package.json'
-    nodejs(version) {
-      // delete node_modules if it's there
-      bat 'if exist node_modules Cmd /C "rmdir /S /Q node_modules"'
-      // install local version of yarn (prevent concurrency issues again)
-      bat 'npm install yarn@' + yarnVersion
-      // force visual studio version
-      bat yarnPath + ' config set msvs_version 2015 --global'
-      // install dependencies with a mutex lock
-      retry(yarnInstallRetries) {
-        bat yarnPath + ' --mutex network --no-lockfile'
-      }
-      // Install custom modules if any
-      installCustomModules(customModules, true)
-      // run actual tests
-      try {
-        bat yarnPath + ' ' + buildStep
-        githubNotify description: 'Tests passed',  status: 'SUCCESS', context: ciContext
-      } catch (err) {
-        githubNotify description: 'Tests failed',  status: 'FAILURE', context: ciContext
-        throw err
-      } finally {
-        junit allowEmptyResults: true, testResults: 'junit-report-*.xml'
-        cleanWs()
-      }
-    }
-  }}}
-}
-
-// Step for running tests on a specific nodejs version with unix compatible OS
-def unixStep(version, nodeLabel, customModules, buildStep) {
-  node(label: nodeLabel) { ansiColor('xterm') { withEnv(['CI=true']) {
-    def ciContext = 'ci/jenkins/' + nodeLabel + '/' + version + '/' + buildStep
-    githubNotify description: 'Tests in progress',  status: 'PENDING', context: ciContext
-    checkout scm
-    fileExists 'package.json'
-    nodejs(version) {
-      sh 'rm -rf node_modules/'
-      sh 'npm install yarn@' + yarnVersion
-      retry(yarnInstallRetries) {
-        sh yarnPath + ' --mutex network --no-lockfile'
-      }
-      installCustomModules(customModules, false)
-      try {
-        if (nodeLabel == 'linux') { // if it's linux, we need xvfb for display emulation (chrome)
-          wrap([$class: 'Xvfb', parallelBuild: true, autoDisplayName: true]) {
-            sh yarnPath + ' ' + buildStep
-            githubNotify description: 'Tests passed',  status: 'SUCCESS', context: ciContext
-          }
-        } else {
-          sh yarnPath + ' ' + buildStep
-          githubNotify description: 'Tests passed',  status: 'SUCCESS', context: ciContext
-        }
-      } catch (err) {
-        githubNotify description: 'Tests failed',  status: 'FAILURE', context: ciContext
-        throw err
-      } finally {
-        junit allowEmptyResults: true, testResults: 'junit-report-*.xml'
-        cleanWs()
-      }
-    }
-  }}}
-}
-
-// Helper function for getting the right platform + version
-def getStep(os, version, customModules, buildStep) {
-  return {
-    if (os == 'macos' || os == 'linux') {
-      return unixStep(version, os, customModules, buildStep)
-    }
-    if (os == 'windows') {
-      return windowsStep(version, customModules, buildStep)
-    }
-  }
-}
-
-
 // Helper to receive the value if it's not empty, or return a default value
 def defVal (value, defaultValue) {
   if (value == null || value == []) {
@@ -115,116 +11,435 @@ def defVal (value, defaultValue) {
   }
 }
 
-def installCustomModules (modules, isWindows) {
+// Installs custom node_modules
+def installCustomModules (os, modules) {
   if (modules != []) {
     def modulesAsString = modules.collect {
       it.key + "@" + it.value
     }.join(" ")
-    if (isWindows) {
-      bat yarnPath + ' add ' + modulesAsString
-    } else {
-      sh yarnPath + ' add ' + modulesAsString
-    }
+    run(os, 'npm install ' + modulesAsString)
   }
 }
 
-def call(opts = []) {
- def nodejsVersions = defVal(opts['nodejs_versions'], defaultNodeVersions)
- def customModules = defVal(opts['node_modules'], [])
- // TODO right now, each customBuildStep will be run in parallel with each other
- // we should enable the use-case where we want them to run after each other
- def customBuildSteps = defVal(opts['custom_build_steps'], ['test'])
- def coverageEnabled = defVal(opts['coverage'], true)
+def isWindows (os) {
+  return os == 'windows'
+}
 
- stage('Tests') {
-  // Create map for all the os+version combinations
-  def steps = [:]
-  for (os in osToTests) {
-      for (nodejsVersion in nodejsVersions) {
-          for (buildStep in customBuildSteps) {
-            def stepName = os + ' - ' + nodejsVersion + ' - ' + buildStep
-            steps[(stepName)] = getStep(os, nodejsVersion, customModules, buildStep)
-          }
-      }
+// Cross-platform sh/bat function
+def run(os, cmd) {
+  if (isWindows(os)) {
+    bat(cmd)
+  } else {
+    sh(cmd)
   }
-  steps['codelint'] = {node(label: 'linux') { ansiColor('xterm') { withEnv(['CI=true']) {
-    def ciContext = 'ci/jenkins/codelint'
-    githubNotify description: 'Linting in progress',  status: 'PENDING', context: ciContext
-    checkout scm
-    fileExists 'package.json'
-    nodejs('9.2.0') {
-        sh 'rm -rf node_modules/'
-        sh 'npm install yarn@' + yarnVersion
-        retry(yarnInstallRetries) {
-          sh yarnPath + ' --mutex network --no-lockfile'
+}
+
+// Same as `run` but with returnStdout
+def runReturnStdout(os, cmd) {
+  if (isWindows(os)) {
+    return bat(script: cmd, returnStdout: true).trim()
+  } else {
+    return sh(script: cmd, returnStdout: true).trim()
+  }
+}
+
+// Same as `run` but with returnStatus
+def runReturnStatus(os, cmd) {
+  if (isWindows(os)) {
+    return bat(script: cmd, returnStatus: true)
+  } else {
+    return sh(script: cmd, returnStatus: true)
+  }
+}
+
+// Checks if package.json contains a certain script
+def packageHasScript(os, script) {
+  def unix = !isWindows(os)
+  def catCmd = unix ? 'cat' : 'type'
+  def grepCmd = unix ? 'grep' : 'FINDSTR'
+  def statusCode = runReturnStatus(os, catCmd + ' package.json | ' + grepCmd + ' ' + script)
+  return statusCode == 0
+}
+
+// Function to wrap calls that needs to cleanup after themselves
+def postClean (f) {
+  try {
+    f()
+  } catch (err) {
+    throw err
+  } finally {
+    cleanWs()
+  }
+}
+
+// Installs dependencies + custom_modules, can turn off/on scripts
+def installDependencies (os, wantedNpmVersion, customModules, ignoreScripts = false) {
+  // TODO currently ignored, should be configured on the worker rather than pipeline
+  // currentVersion = run('npm --version')
+  // if (currentVersion != wantedNpmVersion) {
+  //   run('npm install -g npm@' + wantedNpmVersion)
+  // }
+  if (isWindows(os)) {
+    bat 'npm config set msvs_version 2015 --global'
+  }
+  if (ignoreScripts) {
+    run(os, 'npm install --ignore-scripts')
+  } else {
+    run(os, 'npm install')
+  }
+  installCustomModules(os, customModules)
+}
+
+// Function to wrap calls that might make step unstable rather than failing
+// Used to run the tests because if tests fail, should be marked as unstable (tests failing)
+// rather than failing (something went seriously wrong)
+// TODO doesn't actually set the build to unstable but instead marks it as FAILING
+// as a Jenkins bug prevents us from just marking one stage/node as unstable
+// https://issues.jenkins-ci.org/browse/JENKINS-39203
+def markUnstableIfFail (name, context, f) {
+  // should be something like ci/jenkins/windows/11.0.1/test:node
+  def ciContext = 'ci/jenkins/' + context
+  githubNotify(
+    description: name + ' in progress',
+    status: 'PENDING',
+    context: ciContext
+  )
+  try {
+    f()
+    githubNotify(
+      description: name + ' passed',
+      status: 'SUCCESS',
+      context: ciContext
+    )
+  } catch (err) {
+    githubNotify(
+      description: name + ' failed',
+      status: 'FAILURE',
+      context: ciContext
+    )
+    throw err
+  }
+  // Uncomment once JENKINS-39203 is fixed
+  // try {
+  //   f()
+  // } catch (err) {
+  //   currentBuild.result = 'UNSTABLE'
+  //   println err
+  // }
+}
+
+def collectTestResults (f) {
+  try {
+    f()
+  } catch (err) {
+    throw err
+  } finally {
+    junit allowEmptyResults: true, testResults: 'junit-report-*.xml'
+  }
+}
+
+// Runs common tests for a platform
+def runTests (os, nodejsVersions) {
+  def hasNodeTests = false
+  def hasBrowserTests = false
+  def hasWebWorkerTests = false
+
+  // Need to allocate a node to fetch the stash
+  // TODO should refactor this to be able to do without a node
+  node(label: 'linux') {
+    def data = readVariableStash('variables')
+    hasNodeTests = data.hasNodeTests
+    hasBrowserTests = data.hasBrowserTests
+    hasWebWorkerTests = data.hasWebWorkerTests
+  }
+
+  def sourceStash = 'source-' + os
+  def depsStash = 'deps-' + os + '-' + nodejsVersions[0]
+
+  def linuxSteps = [:]
+  if (hasNodeTests) {
+    for (nodejsVersion in nodejsVersions) {
+      def version = nodejsVersion
+      def stepName = version + ' test:node'
+      def depsVersionStash = 'deps-' + os + '-' + version
+      def context = os + '/' + version + '/test:node'
+
+      linuxSteps[stepName] = {node(label: os) { postClean {
+        unstash sourceStash
+        unstash depsVersionStash
+        nodejs(version) {
+          collectTestResults { markUnstableIfFail 'node tests', context, {
+            run(os, 'npm run test:node')
+          }}
         }
-        installCustomModules(customModules, false)
-        try {
-          sh yarnPath + ' lint'
-          githubNotify description: 'Linting passed',  status: 'SUCCESS', context: ciContext
-        } catch (err) {
-          githubNotify description: 'Linting failed',  status: 'FAILURE', context: ciContext
-          throw err
-        } finally {
-          cleanWs()
-        }
+      }}}
     }
-  }}}}
-  steps['commitlint'] = {node(label: 'linux') { ansiColor('xterm') { withEnv(['CI=true']) {
-    def ciContext = 'ci/jenkins/commitlint'
-    githubNotify description: 'Linting in progress',  status: 'PENDING', context: ciContext
-    checkout scm
-    fileExists 'package.json'
-    nodejs('9.2.0') {
-        sh 'rm -rf node_modules/'
-        sh 'npm install yarn@' + yarnVersion
-        retry(yarnInstallRetries) {
-          sh yarnPath + ' add --no-lockfile @commitlint/config-conventional @commitlint/cli'
-        }
-        try {
-          def commit = sh(returnStdout: true, script: "git rev-parse remotes/origin/$BRANCH_NAME").trim()
-          sh 'git remote set-branches origin master && git fetch'
-          sh "./node_modules/.bin/commitlint --extends=@commitlint/config-conventional --from=remotes/origin/master --to=$commit"
-          githubNotify description: 'Linting passed',  status: 'SUCCESS', context: ciContext
-        } catch (err) {
-          githubNotify description: 'Linting failed',  status: 'FAILURE', context: ciContext
-          throw err
-        } finally {
-          cleanWs()
-        }
-    }
-  }}}}
-  if (coverageEnabled) {
-    steps['coverage'] = {node(label: 'linux') { ansiColor('xterm') { withEnv(['CI=true']) {
-      checkout scm
-      fileExists 'package.json'
-      nodejs('9.2.0') {
-        sh 'npm install yarn@' + yarnVersion
-        retry(yarnInstallRetries) {
-          sh yarnPath + ' --mutex network'
-        }
-        try {
-          sh 'env | sort'
-          def repo = sh(returnStdout: true, script: "git remote get-url origin | cut -d '/' -f 4,5 | cut -d '.' -f 1").trim()
-          withCredentials([string(credentialsId: 'codecov-test-access-code', variable: 'CODECOV_ACCESS_TOKEN')]) {
-            def codecovToken = sh(returnStdout: true, script: "curl --silent \"https://codecov.io/api/gh/$repo?access_token=\$CODECOV_ACCESS_TOKEN\" | node -e \"let data = '';process.stdin.on('data', (d) => data = data + d.toString());process.stdin.on('end', () => console.log(JSON.parse(data).repo.upload_token));\"").trim()
-            withEnv(["CODECOV_TOKEN=$codecovToken"]) {
-              sh yarnPath + ' coverage -u -p codecov'
-            }
+  }
+  if (hasBrowserTests) {
+   linuxSteps['test:browser'] = {node(label: os) { postClean {
+     unstash sourceStash
+     unstash depsStash
+     nodejs(nodejsVersions[0]) {
+       def testCmd = 'npm run test:browser'
+       def context = os + '/test:browser'
+       if (os == 'linux') {
+         wrap([$class: 'Xvfb', parallelBuild: true, autoDisplayName: true]) {
+           collectTestResults { markUnstableIfFail 'browser tests', context, {
+             run(os, testCmd)
+           }}
+         }
+       } else {
+         collectTestResults { markUnstableIfFail 'browser tests', context, {
+           run(os, testCmd)
+         }}
+       }
+     }
+   }}}
+  }
+  if (hasWebWorkerTests) {
+   linuxSteps['test:webworker'] = {node(label: os) { postClean {
+     unstash sourceStash
+     unstash depsStash
+     nodejs(nodejsVersions[0]) {
+       def testCmd = 'npm run test:webworker'
+       def context = os + '/test:webworker'
+       if (os == 'linux') {
+         wrap([$class: 'Xvfb', parallelBuild: true, autoDisplayName: true]) {
+           collectTestResults { markUnstableIfFail 'webworker tests', context, {
+             run(os, testCmd)
+           }}
+         }
+       } else {
+         collectTestResults { markUnstableIfFail 'webworker tests', context, {
+           run(os, testCmd)
+         }}
+       }
+     }
+   }}}
+  }
+  parallel linuxSteps
+}
+
+// Utility function to use with writeVariableStash
+def createInitialJSONData () {
+  return readJSON(text: '{}')
+}
+
+def writeVariableStash (name, jsonData) {
+  writeJSON(file: name + '.jenkins.json', json: jsonData)
+  stash(name: 'json-' + name, includes: name + '.jenkins.json')
+}
+
+def readVariableStash (name) {
+  unstash('json-' + name)
+  return readJSON(file: name + '.jenkins.json')
+}
+
+def readVariableStash (name, variable) {
+  def data = readVariableStash(name)
+  return data[variable]
+}
+
+def call(opts = []) {
+  // Which NodeJS versions to use
+  def defaultNodeVersions = [
+    '8.11.3',
+    '10.4.1'
+  ]
+  // Which OSes to test on
+  def osToTests = [
+    'macos',
+    'windows',
+    'linux'
+  ]
+
+  def yarnVersion = '1.9.4'
+  def yarnPath = './node_modules/.bin/yarn --registry="https://registry.npmjs.com"'
+  def yarnInstallRetries = 3
+  def npmVersion = '6.4.1'
+
+   def nodejsVersions = defVal(opts['nodejs_versions'], defaultNodeVersions)
+   def customModules = defVal(opts['node_modules'], [])
+   // TODO should be automatically infered
+   def coverageEnabled = defVal(opts['coverage'], true)
+   // TODO linting should be infered as well
+
+   pipeline {
+     agent none
+     environment {
+       CI = true
+     }
+     options {
+       ansiColor('xterm')
+       // Enables retrying of failing stages
+       preserveStashes(buildCount: 20)
+       // TODO only shows up in classic UI, not Blue Ocean :(
+       timestamps()
+     }
+     stages {
+       // TODO currently run on each platform due to cross-platform issues, but
+       // should be able to run once on linux and shared on platforms
+       stage('Fetch Source') {
+         steps {
+           script {
+             def fetchSteps = [:]
+             for (os in osToTests) {
+              def sourceStash = 'source-' + os
+              fetchSteps[os] = {
+                node(label: os) { postClean {
+                  run(os, 'git config --global core.autocrlf input')
+                  checkout scm
+                  stash name: sourceStash, excludes: 'node_modules/**', useDefaultExcludes: false
+                }}
+              }
+             }
+             parallel(fetchSteps)
+           }
+         }
+       }
+
+       stage('Check available scripts') {
+        steps {
+          script {
+            def os = 'linux'
+            node(label: os) { postClean {
+              unstash 'source-linux'
+              jsonData = createInitialJSONData()
+              jsonData.hasNodeTests = packageHasScript(os, 'test:node')
+              jsonData.hasBrowserTests = packageHasScript(os, 'test:browser')
+              jsonData.hasWebWorkerTests = packageHasScript(os, 'test:webworker')
+              writeVariableStash('variables', jsonData)
+            }}
           }
-        } catch (err) {
-          println err
-        } finally {
-          cleanWs()
         }
-      }
-    }}}}
-  }
-  // Maximum runtime: 1 hour
-  timeout(time: 1, unit: 'HOURS') {
-    // execute those steps in parallel
-    parallel steps
-  }
- }
+       }
+
+       // TODO should be able to run on one platform (linux) and just post-install
+       // on each platform + version but npm works differently on platforms...
+       stage('Fetch Deps') { steps { script {
+         def depsSteps = [:]
+         for (os in osToTests) {
+           def stepName = os
+           def rawDepsStash = 'raw-deps-' + os
+           def sourceStash = 'source-' + os
+           def version = nodejsVersions[0]
+           def currentOS = os
+
+           depsSteps[stepName] = {node(label: currentOS) { postClean {
+             unstash sourceStash
+             nodejs(version) {
+               installDependencies(currentOS, npmVersion, customModules, true)
+               stash name: rawDepsStash, includes: 'node_modules/**', useDefaultExcludes: false
+             }
+           }}}
+         }
+         parallel depsSteps
+       }}}
+       stage('Deps Post-Install') { steps { script {
+         def depsSteps = [:]
+         for (os in osToTests) {
+           for (nodejsVersion in nodejsVersions) {
+             def stepName = os + ' - ' + nodejsVersion
+             def rawDepsStash = 'raw-deps-' + os
+             def depsStash = 'deps-' + os + '-' + nodejsVersion
+             def sourceStash = 'source-' + os
+             def version = nodejsVersion
+             def currentOS = os
+
+             depsSteps[stepName] = {node(label: currentOS) { postClean {
+               unstash sourceStash
+               unstash rawDepsStash
+               nodejs(version) {
+                 // Might have to add this at one point but seems fine for now
+                 // installDependencies(currentOS, npmVersion, customModules)
+                 if (isWindows(currentOS)) {
+                   bat 'npm config set msvs_version 2015 --global'
+                 }
+                 run(currentOS, 'npm rebuild')
+                 stash name: depsStash, includes: 'node_modules/**', useDefaultExcludes: false
+               }
+             }}}
+           }
+         }
+         parallel depsSteps
+       }}}
+
+       stage('Checks') {
+        steps {
+          script {
+            def os = 'linux'
+            def checksSteps = [:]
+            checksSteps['codelint'] = { node(label: os) { postClean {
+              unstash 'source-linux'
+              unstash 'deps-linux-' + nodejsVersions[0]
+              nodejs(nodejsVersions[0]) {
+                markUnstableIfFail 'code linting', 'codelint', {
+                  run(os, 'npm run lint')
+                }
+              }
+            }}}
+            checksSteps['commitlint'] = { node(label: os) { postClean {
+              unstash 'source-linux'
+              nodejs(nodejsVersions[0]) {
+                sh 'npm install --no-lockfile @commitlint/config-conventional @commitlint/cli'
+                def commit = runReturnStdout(os, "git rev-parse remotes/origin/$BRANCH_NAME")
+                run(os, 'git remote set-branches origin master && git fetch')
+                markUnstableIfFail 'commit linting', 'commitlint', {
+                  run(os, "./node_modules/.bin/commitlint --extends=@commitlint/config-conventional --from=remotes/origin/master --to=$commit")
+                }
+              }
+            }}}
+            parallel checksSteps
+          }
+        }
+       }
+
+       stage('Linux Tests') {
+        steps {
+          script {
+            runTests('linux', nodejsVersions)
+          }
+        }
+       }
+       stage('Windows Tests') {
+        steps {
+          script {
+            runTests('windows', nodejsVersions)
+          }
+        }
+       }
+       stage('macOS Tests') {
+        steps {
+          script {
+            runTests('macos', nodejsVersions)
+          }
+        }
+       }
+       stage('Coverage') {
+        steps {
+          script {
+            def os = 'linux'
+            node(label: os) { postClean {
+              unstash 'source-linux'
+              unstash 'deps-linux-' + nodejsVersions[0]
+              nodejs(nodejsVersions[0]) {
+                def repo = runReturnStdout(os, "git remote get-url origin | cut -d '/' -f 4,5 | cut -d '.' -f 1")
+                withCredentials([
+                  string(
+                    credentialsId: 'codecov-test-access-code',
+                    variable: 'CODECOV_ACCESS_TOKEN'
+                  )]) {
+                  def codecovToken = runReturnStdout(os, "curl --silent \"https://codecov.io/api/gh/$repo?access_token=\$CODECOV_ACCESS_TOKEN\" | node -e \"let data = '';process.stdin.on('data', (d) => data = data + d.toString());process.stdin.on('end', () => console.log(JSON.parse(data).repo.upload_token));\"")
+                  withEnv(["CODECOV_TOKEN=$codecovToken"]) {
+                 markUnstableIfFail 'coverage', 'coverage', {
+                   run(os, 'npm run coverage -u -p codecov')
+                 }
+                  }
+                }
+              }
+          }}}}
+       }
+     }
+   }
 }
 


### PR DESCRIPTION
This commit changes the old scriptable pipeline into a declarative
pipeline.

Benefits are:

  - Everything split into stages that can be restarted if needed without
    restarting the entire pipeline
  - Future possibility to cache stashes between builds (not having to run
    `npm install` on every build if previously successful)
  - Faster reporting of `node | browser | webworker` CI status since we
    run platforms sequentially with this commit
  - Better support and stability from Jenkins (development efforts are
    focused on declerative pipelines)

Drawbacks:
   - If the entire build itself is fully successful, it'll take longer than before
        as stashing/unstashing adds some build time.

Missing changes:

  - Confirmation from JS-team on the order of tests
    - We might want to run `coverage` before platform tests etc etc
    - Flaky tests should end up last, so we retry as little of the
      pipeline as possible

Example pipeline:
![image](https://user-images.githubusercontent.com/459764/45917489-8914e100-be78-11e8-8f87-fd57f38a8f33.png)
https://ci.ipfs.team/blue/organizations/jenkins/Multiformats%2Fjs-multiaddr/detail/master/74/pipeline


License: MIT
Signed-off-by: Victor Bjelkholm <git@victor.earth>