### PR TITLE
Install custom modules first

### DIFF
--- a/vars/javascript.groovy
+++ b/vars/javascript.groovy
@@ -89,12 +89,12 @@ def installDependencies (os, wantedNpmVersion, customModules, ignoreScripts = fa
   if (isWindows(os)) {
     bat 'npm config set msvs_version 2015 --global'
   }
+  installCustomModules(os, customModules)
   if (ignoreScripts) {
     run(os, 'npm install --ignore-scripts')
   } else {
     run(os, 'npm install')
   }
-  installCustomModules(os, customModules)
 }
 
 // Function to wrap calls that might make step unstable rather than failing


### PR DESCRIPTION
With installing custom modules first, it's possible to override modules
from package.json.

The use case is dependencies that are not published yet, but are pushed
to some branch already. For example you have made a PR on js-ipfs that
also needs to have a test in interface-ipfs-core updated. You plan to have
this change released in the next version of interface-ipfs-core. So you
already update you package.json of js-ipfs to point to that new release.

If you would do an `npm install` it would fail as that version of
interface-ipfs-core isn't released yet. To make CI work though, you
can pass in the interface-ipfs-core branch that contains this change.

Just click on `Replay` in the classic Jenkins UI and change the
"Main Script" from

    javascript()

to

    javascript(node_modules: [
      'interface-ipfs-core': 'ipfs/interface-ipfs-core#my-updated-tests'
    ])

Jenkins will now checkout js-ipfs from GitHub and then `npm install`
the custom interface-ipfs-core branch. This will override the
package.json file, so a subsequent `npm install` will work and
install everything else as usual.