### PR TITLE
Make npm use Python 2.7 on Windows

### DIFF
--- a/vars/javascript.groovy
+++ b/vars/javascript.groovy
@@ -88,6 +88,7 @@ def installDependencies (os, wantedNpmVersion, customModules, ignoreScripts = fa
   // }
   if (isWindows(os)) {
     bat 'npm config set msvs_version 2015 --global'
+    bat 'npm config set python c:\\python27\\python.exe --global'
   }
   if (ignoreScripts) {
     run(os, 'npm install --ignore-scripts')


### PR DESCRIPTION
Node.js projects that use GYP for compilation need Python 2.7.
Python 2.7 is installed an in the path, but sometimes npm picks
up Python 3 instead. With setting it explicitely to the Python 2.7
installation things will build correctly.

Fixes https://github.com/ipfs/dev-team-enablement/issues/155.

it was tested manually. Here's a run without the fix:
https://ci.ipfs.team/job/IPLD/job/js-ipld/job/PR-153/15/consoleFull

And here on with the fix:
https://ci.ipfs.team/job/IPLD/job/js-ipld/job/PR-153/14/consoleFull