### PR TITLE
fix: preload should not block the website build

### DIFF
--- a/vars/website.groovy
+++ b/vars/website.groovy
@@ -114,7 +114,7 @@ def call(opts = []) {
               versionsHash = sh(returnStdout: true, script: "ipfs add -Q ./_previous-versions").trim()
               websiteHash = sh(returnStdout: true, script: "ipfs object patch $websiteHash add-link _previous-versions $versionsHash").trim()
               sh "ipfs pin add --progress $websiteHash"
-              sh "curl -s \"https://node" + new Random().nextInt(2) +".preload.ipfs.io/api/v0/refs?r=true&arg=${websiteHash}\""
+              sh "nohup curl --max-time 900 -s \"https://node" + new Random().nextInt(2) +".preload.ipfs.io/api/v0/refs?r=true&arg=${websiteHash}\" >/dev/null 2>&1 &"
               cleanWs()
             } catch (err) {
               currentBuild.result = hudson.model.Result.FAILURE.toString()
@@ -143,13 +143,13 @@ def call(opts = []) {
             }
             sh "ipfs refs -r $websiteHash"
             sh "ipfs pin add --progress $websiteHash"
-            sh "curl -s \"https://node" + new Random().nextInt(2) +".preload.ipfs.io/api/v0/refs?r=true&arg=${websiteHash}\""
+            sh "nohup curl --max-time 900 -s \"https://node" + new Random().nextInt(2) +".preload.ipfs.io/api/v0/refs?r=true&arg=${websiteHash}\" >/dev/null 2>&1 &"
           }
           def websiteUrl = "https://ipfs.io/ipfs/$websiteHash"
           sh "set +x && curl -X POST -H 'Content-Type: application/json' --data '{\"state\": \"success\", \"target_url\": \"$websiteUrl\", \"description\": \"A rendered preview of this commit\", \"context\": \"Rendered Preview\"}' -H \"Authorization: Bearer \$(cat /tmp/userauthtoken)\" https://api.github.com/repos/$githubOrg/$githubRepo/statuses/$gitCommit"
           echo "New website: $websiteUrl"
           if (record["$BRANCH_NAME"] && !disablePublish) {
-            sh 'wget https://ipfs.io/ipfs/QmUFECnqabdoRJePDAQ35awTWeoQhHiz1LujSh3zwBBXCz/dnslink-dnsimple -O dnslink-dnsimple'
+            sh 'wget --quiet https://ipfs.io/ipfs/QmUFECnqabdoRJePDAQ35awTWeoQhHiz1LujSh3zwBBXCz/dnslink-dnsimple -O dnslink-dnsimple'
             sh 'chmod +x dnslink-dnsimple'
             token = readFile '/tmp/dnsimpletoken'
             token = token.trim()


### PR DESCRIPTION
This PR applies a small improvement over https://github.com/ipfs/jenkins-libs/pull/37: runs time-bound preload request in the background (best-effort) so even if the preload node is down or extremely slow, the build will not break nor take a long time to finish.

cc @Stebalien @VictorBjelkholm 
