### PR TITLE
Use Go 1.11.x

### DIFF
--- a/vars/golang.groovy
+++ b/vars/golang.groovy
@@ -17,14 +17,15 @@ def defVal (value, defaultValue) {
 
 def call(opts = []) {
   def env = defVal(opts['env'], defaultEnv)
-  def test = defVal(opts['test'], defaultTest)  
-  def root = tool name: '1.11.4', type: 'go'
+  def test = defVal(opts['test'], defaultTest)
+  def goName = '1.11'
   timeout(time: 1, unit: 'HOURS') {
     stage('tests') {
       parallel(
         windows: {
           node(label: 'windows') {
             ansiColor('xterm') {
+              def root = tool name: "${goName}", type: 'go'
               def jobNameArr = "${JOB_NAME}"
               def jobName = jobNameArr.split("/")[0..1].join("\\\\").toLowerCase()
               def originalWs = "${WORKSPACE}"
@@ -53,6 +54,7 @@ def call(opts = []) {
         linux: {
           node(label: 'linux') {
             ansiColor('xterm') {
+              def root = tool name: "${goName}", type: 'go'
               def jobNameArr = "${JOB_NAME}"
               def jobName = jobNameArr.split("/")[0..1].join("/").toLowerCase()
               def originalWs = "${WORKSPACE}"
@@ -81,6 +83,7 @@ def call(opts = []) {
         macOS: {
           node(label: 'macos') {
             ansiColor('xterm') {
+              def root = tool name: "${goName}", type: 'go'
               def jobNameArr = "${JOB_NAME}"
               def jobName = jobNameArr.split("/")[0..1].join("/").toLowerCase()
               def originalWs = "${WORKSPACE}"

--- a/vars/golang.groovy
+++ b/vars/golang.groovy
@@ -17,14 +17,14 @@ def defVal (value, defaultValue) {
 
 def call(opts = []) {
   def env = defVal(opts['env'], defaultEnv)
-  def test = defVal(opts['test'], defaultTest)
+  def test = defVal(opts['test'], defaultTest)  
+  def root = tool name: '1.11.4', type: 'go'
   timeout(time: 1, unit: 'HOURS') {
     stage('tests') {
       parallel(
         windows: {
           node(label: 'windows') {
             ansiColor('xterm') {
-              def root = tool name: '1.10.2', type: 'go'
               def jobNameArr = "${JOB_NAME}"
               def jobName = jobNameArr.split("/")[0..1].join("\\\\").toLowerCase()
               def originalWs = "${WORKSPACE}"
@@ -53,7 +53,6 @@ def call(opts = []) {
         linux: {
           node(label: 'linux') {
             ansiColor('xterm') {
-              def root = tool name: '1.10.2', type: 'go'
               def jobNameArr = "${JOB_NAME}"
               def jobName = jobNameArr.split("/")[0..1].join("/").toLowerCase()
               def originalWs = "${WORKSPACE}"
@@ -82,7 +81,6 @@ def call(opts = []) {
         macOS: {
           node(label: 'macos') {
             ansiColor('xterm') {
-              def root = tool name: '1.10.2', type: 'go'
               def jobNameArr = "${JOB_NAME}"
               def jobName = jobNameArr.split("/")[0..1].join("/").toLowerCase()
               def originalWs = "${WORKSPACE}"


### PR DESCRIPTION
Not sure if this change is too hopeful. Go 1.11 is required for packages using its new socket Control API.